### PR TITLE
Updating naming to carriers in "Regional View" 

### DIFF
--- a/utilities/GenerationMixChartConfig.ts
+++ b/utilities/GenerationMixChartConfig.ts
@@ -154,11 +154,11 @@ export const GenerationMixchartConfigSmall = {
     color: "hsl(var(--chart-ror))",
   },
   "offwind-ac": {
-    label: "off wind ac",
+    label: "Onshore Wind",
     color: "hsl(var(--chart-offwind-ac))",
   },
   "offwind-dc": {
-    label: "off wind dc",
+    label: "Offshore Wind",
     color: "hsl(var(--chart-offwind-dc))",
   },
 } satisfies ChartConfig;


### PR DESCRIPTION
Fixed @ElectricMountains suggestion in Carriers "offwind ac" and "offwind dc".