### PR TITLE
Introduce netlify github action

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,27 @@
+# See https://github.com/marketplace/actions/netlify-actions
+name: Build and Deploy to Netlify
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # ( Build to ./dist or other directory... )
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: "./.next/"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1


### PR DESCRIPTION
This PR introduces a github action that deploys to Netlify to show previews during pull requests.

To set up
- Register with your github account on netlify
- Add a website and select the current github repository
- Ensure the variables are set for NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID (I believe netlify has automatically taken those when I authenticated with them)
- Set up the environment variables for the SQL connection on the netlify page

Note: I believe simply setting up a netlify account and adding the github project may be enough, hence this PR may not be necessary.