### PR TITLE
Remove Brazil from globe

### DIFF
--- a/app/api/geography/config.ts
+++ b/app/api/geography/config.ts
@@ -19,7 +19,6 @@ export const pool = new Pool({
 // Valid country codes
 export const VALID_COUNTRIES = [
   "au",
-  "br",
   "co",
   "de",
   "in",


### PR DESCRIPTION
Brazil is removed for the time being due to reevaluation.

Fixes #193 